### PR TITLE
[AF-1703] Fix for blob where responseText is undefined

### DIFF
--- a/delete_non_clonable.js
+++ b/delete_non_clonable.js
@@ -78,16 +78,18 @@ function deleteNonClonable(obj, depth) {
         }
         case 'XMLHttpRequest':
             var newXHR = {
-                readyState: obj.readyState,
-                responseText: obj.responseText,
-                status: obj.status,
-                statusText: obj.statusText
+                  readyState: obj.readyState,
+                  status: obj.status,
+                  statusText: obj.statusText
             };
-            try {
-                newXHR.responseJSON = JSON.parse(obj.responseText);
-            }
-            catch (error) { }
-            ;
+            if (obj.reponseType !== 'blob') {
+              newXHR.responseText = obj.responseText;
+              try {
+                  newXHR.responseJSON = JSON.parse(obj.responseText);
+              }
+              catch (error) { }
+              ;
+            };
             return newXHR;
         default:
             if (/^(?:Int|Uint|Float)(?:8|16|32|64)Array$/.test(type)) {

--- a/delete_non_clonable.js
+++ b/delete_non_clonable.js
@@ -82,7 +82,7 @@ function deleteNonClonable(obj, depth) {
                   status: obj.status,
                   statusText: obj.statusText
             };
-            if (obj.reponseType !== 'blob') {
+            if (obj.reponseType === 'text' || obj.responseType === '') {
               newXHR.responseText = obj.responseText;
               try {
                   newXHR.responseJSON = JSON.parse(obj.responseText);


### PR DESCRIPTION
@zendesk/vegemite

We have a problem presently when the `apps_new_ajax_request` arturo is 'on', in that XMLHttpRequest breaks for responseType 'blob'.

This change fixes this problem by not trying to include responseText in the response object if the type is blob.

### References
* https://zendesk.atlassian.net/browse/AF-1703

### Risks
* There might be a security concern with allowing blob data types ...?