### PR TITLE
Set responseText or repsonse

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains a utility for sanitising Javascript objects before passing th
 Add to your `package.json` by
 
 ```sh
-yarn add post_message_filter
+npm add post_message_filter
 ```
 
 Then in your code
@@ -25,8 +25,10 @@ function postMessageWrapper(message, targetOrigin) {
 
 ## Building
 
+The `delete_non_clonable.js` is the **build** file, the `.ts` file the source.
+
 ```sh
-yarn build
+npm run build
 ```
 
 ## Browser Support

--- a/delete_non_clonable.js
+++ b/delete_non_clonable.js
@@ -79,10 +79,13 @@ function deleteNonClonable(obj, depth) {
         case 'XMLHttpRequest':
             var newXHR = {
                 readyState: obj.readyState,
-                responseText: obj.responseText,
                 status: obj.status,
                 statusText: obj.statusText
             };
+            if (obj.responseType === 'arraybuffer' || obj.responseType === 'blob')
+                newXHR.response = obj.response;
+            else
+                newXHR.responseText = obj.responseText;
             try {
                 newXHR.responseJSON = JSON.parse(obj.responseText);
             }

--- a/delete_non_clonable.ts
+++ b/delete_non_clonable.ts
@@ -20,9 +20,10 @@ function toStringForObject(object: any): string {
 
 interface XHRObject {
   readyState: number
-  responseText: string
   status: string
   statusText: string
+  response?: string
+  responseText?: string
   responseJSON?: object
 }
 
@@ -88,10 +89,14 @@ export default function deleteNonClonable(obj: any, depth: number = 0) {
     case 'XMLHttpRequest':
       const newXHR: XHRObject = {
         readyState: obj.readyState,
-        responseText: obj.responseText,
         status: obj.status,
         statusText: obj.statusText
       };
+
+      if (obj.responseType === 'arraybuffer' || obj.responseType === 'blob')
+        newXHR.response = obj.response;
+      else
+        newXHR.responseText = obj.responseText;
 
       try {
         newXHR.responseJSON = JSON.parse(obj.responseText);


### PR DESCRIPTION
Depending on the responseType, the info is either in `repsonse` or in `responseText`. Use accordingly.

According to https://developer.mozilla.org/en-US/docs/Web/API/XMLHttpRequest/responseType the values can be: `arraybuffer`, `blob`, `document`, `json`, `text` or `''`.

| Type          | .response     | .responseText     | .responseXML       |
| ------------- |:-------------:|:-----------------:| ------------------:|
| ''            | *             | String or Error   | Document or Error  |
| arraybuffer   | ArrayBuffer   | Error             | Error              |
| blob          | Blob          | Error             | Error              |
| document      | Document      | Error             | Document           |
| json          | Object        | Error             | Error              |
| text          | String        | String            | Error              |

Also added info to README