### PR TITLE
[AF-1718] Simply convert to object

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ This repo contains a utility for sanitising Javascript objects before passing th
 Add to your `package.json` by
 
 ```sh
-yarn add post_message_filter
+npm add post_message_filter
 ```
 
 Then in your code
@@ -25,8 +25,10 @@ function postMessageWrapper(message, targetOrigin) {
 
 ## Building
 
+The `delete_non_clonable.js` is the **build** file, the `.ts` file the source.
+
 ```sh
-yarn build
+npm run build
 ```
 
 ## Browser Support

--- a/delete_non_clonable.js
+++ b/delete_non_clonable.js
@@ -79,16 +79,16 @@ function deleteNonClonable(obj, depth) {
         case 'XMLHttpRequest':
             var newXHR = {
                 readyState: obj.readyState,
-                responseText: obj.responseText,
+                response: obj.response,
                 status: obj.status,
                 statusText: obj.statusText
             };
             try {
-                newXHR.responseJSON = JSON.parse(obj.responseText);
+                newXHR.responseText = obj.responseText;
             }
             catch (error) { }
             ;
-            return newXHR;
+            return deleteNonClonable(newXHR);
         default:
             if (/^(?:Int|Uint|Float)(?:8|16|32|64)Array$/.test(type)) {
                 // close enough to https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView

--- a/delete_non_clonable.ts
+++ b/delete_non_clonable.ts
@@ -20,10 +20,10 @@ function toStringForObject(object: any): string {
 
 interface XHRObject {
   readyState: number
-  responseText: string
+  responseText?: string
   status: string
   statusText: string
-  responseJSON?: object
+  response: any
 }
 
 export default function deleteNonClonable(obj: any, depth: number = 0) {
@@ -88,16 +88,16 @@ export default function deleteNonClonable(obj: any, depth: number = 0) {
     case 'XMLHttpRequest':
       const newXHR: XHRObject = {
         readyState: obj.readyState,
-        responseText: obj.responseText,
+        response: obj.response,
         status: obj.status,
         statusText: obj.statusText
       };
 
       try {
-        newXHR.responseJSON = JSON.parse(obj.responseText);
+        newXHR.responseText = obj.responseText;
       } catch (error) {};
 
-      return newXHR;
+      return deleteNonClonable(newXHR);
     default:
       if (/^(?:Int|Uint|Float)(?:8|16|32|64)Array$/.test(type)) {
         // close enough to https://developer.mozilla.org/en-US/docs/Web/API/ArrayBufferView


### PR DESCRIPTION
For some reason last week I invented `responseJSON`.

In hindsight, let's just keep the input and output structure the same!

`response`, `responseText`. We don't pass pass `responseXML` since it's a XML document.

JIRA: https://zendesk.atlassian.net/browse/AF-1718